### PR TITLE
transpile bundles for ie support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.cache/

--- a/src/index.html
+++ b/src/index.html
@@ -7,6 +7,9 @@
     <link href="https://fonts.googleapis.com/css?family=Barlow+Semi+Condensed&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="./css/bootstrap.min.css">
     <!-- <link rel="stylesheet" href="./css/dx-styles.css"> -->
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/babel-polyfill/7.4.3/polyfill.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/custom-elements/1.2.4/custom-elements.min.js"></script>
 </head>
 
 <body>

--- a/tasks/build.js
+++ b/tasks/build.js
@@ -1,4 +1,6 @@
 process.env.NODE_ENV = 'production';
+const transpileForIE = require('./transpile-for-ie');
+
 
 const Bundler = require("parcel-bundler"),
   Path = require("path"),
@@ -26,5 +28,6 @@ fs.removeSync('dist');
 const bundler = new Bundler(entryFiles, options);
 
 bundler.bundle().then(() => {
+  transpileForIE("dist");
   console.log("done building");
 }, e => console.log(e));

--- a/tasks/dev.js
+++ b/tasks/dev.js
@@ -1,3 +1,5 @@
+const transpileForIE = require('./transpile-for-ie');
+
 const Bundler = require("parcel-bundler"),
   Path = require("path"),
   browserSync = require("browser-sync").create(),
@@ -31,7 +33,12 @@ bundler.on("bundled", async () => {
 });
 
 bundler.on("buildEnd", () => {
-  browserSync.reload();
+  // setTimeout is to avoid browserSync throwing an error
+  // after the IE11 transpile is done 
+  setTimeout(function() {
+    transpileForIE("dist");
+    browserSync.reload();
+  },0)
 });
 
 bundler.bundle();

--- a/tasks/transpile-for-ie.js
+++ b/tasks/transpile-for-ie.js
@@ -1,0 +1,37 @@
+const fs = require('fs-extra');
+const babel = require('@babel/core')
+
+function transpileFileForIE(path) {
+    const code = babel.transformFileSync(path, {
+        "presets": [
+            [
+              "@babel/preset-env",
+              {
+                "modules": false,
+                "targets": {
+                    "ie": "11"
+                  }
+              }
+            ]
+          ]
+    }).code;
+    fs.writeFileSync(path, code);
+}
+
+function transpileForIE(folderPath) {
+    const files = fs.readdirSync(`${folderPath}`);
+
+    const filesToBuildForIE = [];
+    files.forEach(file => {
+        if (file.indexOf('.js') === file.length-3) {
+            filesToBuildForIE.push(file);
+        }
+    });
+
+    for (let i=0;i<filesToBuildForIE.length;i++) {
+        transpileFileForIE(`${folderPath}/${filesToBuildForIE[i]}`);
+    }
+
+    console.log("JS bundles transpiled to ES5 for IE11 support.");
+}
+module.exports = transpileForIE;


### PR DESCRIPTION
Tested on my VM and this seems to work ok.  A couple notes:

1. Currently this ES5 bundle is being served to all browsers.  I usually create 2 separate bundles, one for modern browsers and one for IE11 and conditionally serve one or the other using something like https://github.com/muicss/loadjs . Let me know if you want me to setup an example of that too.

2. The reason we are having to build the code with parcel and then run it through babel separately is that the Polymer team (Lit-Element) is only distributing their code as ES6 modules (no commonJS or AMD options).  In addition, Parcel (and maybe webpack too) don't want to transpile anything within the node_modules directory as that would slow down the build quite a bit if they transpiled everything.  Maybe webpack has already addressed this, note sure, but it should be available in Parcel in the future: https://github.com/parcel-bundler/parcel/issues/1655

3. Because we are transpiling the JS AFTER source maps were created, the source maps are almost certainly wrong, so you should disable JS source maps in the browser when debugging. : (
